### PR TITLE
Handle bracketed structured core keys and add regression test

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -16,3 +16,13 @@ def test_interpreter_emotion_payload():
     env = run_chaos(src)
     assert any(e.get("type") == "HOPE" or e.get("name") == "HOPE" for e in env["emotive_layer"])
 
+
+def test_structured_core_preserves_relation_box():
+    with open("chaos_corpus/relation_box.sn", "r", encoding="utf-8") as handle:
+        src = handle.read()
+    env = run_chaos(src)
+    structured = env.get("structured_core", {})
+    assert structured.get("EVENT") == "relation"
+    assert structured.get("OBJECT:BOX") == "ATTRIBUTE:WOOD"
+    assert structured.get("OBJECT:GIFT") == "ATTRIBUTE:SMALL"
+


### PR DESCRIPTION
## Summary
- capture complete bracketed identifiers for structured core keys and allow bracketed values to be stored
- relax emotive parsing to tolerate multi-segment tags while preserving emotion intensity handling
- add a regression test ensuring relation_box retains object and attribute pairs in the structured core

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc50ce53788327b57384d8e0524209