### PR TITLE
Fix CHAOS agent intensity handling

### DIFF
--- a/chaos_agent.py
+++ b/chaos_agent.py
@@ -55,8 +55,15 @@ class ChaosAgent:
             self.log.log(f"symbol {symbol_key}={value}")
         for entry in emotive_layer:
             name = norm_key(entry.get("type") or entry.get("name") or "FEELING")
-            raw = entry.get("intensity") or 5
-            intensity = clamp(int(raw) if str(raw).isdigit() else 5, 0, 10)
+            raw = entry.get("intensity")
+            if raw is None:
+                parsed = 5
+            else:
+                try:
+                    parsed = int(raw)
+                except (TypeError, ValueError):
+                    parsed = 5
+            intensity = clamp(parsed, 0, 10)
             self.emotions.push(name, intensity)
             self.log.log(f"emotion {name}:{intensity}")
         if chaosfield_layer:

--- a/chaos_agent.py
+++ b/chaos_agent.py
@@ -11,7 +11,7 @@ from chaos_graph import ChaosGraph
 from chaos_logger import ChaosLogger
 from chaos_protocols import ProtocolRegistry
 from chaos_runtime import run_chaos
-from chaos_stdlib import clamp, norm_key, text_snippet
+from chaos_stdlib import norm_key, soft_intensity, text_snippet
 
 
 @dataclass
@@ -56,14 +56,7 @@ class ChaosAgent:
         for entry in emotive_layer:
             name = norm_key(entry.get("type") or entry.get("name") or "FEELING")
             raw = entry.get("intensity")
-            if raw is None:
-                parsed = 5
-            else:
-                try:
-                    parsed = int(raw)
-                except (TypeError, ValueError):
-                    parsed = 5
-            intensity = clamp(parsed, 0, 10)
+            intensity = soft_intensity(raw)
             self.emotions.push(name, intensity)
             self.log.log(f"emotion {name}:{intensity}")
         if chaosfield_layer:
@@ -125,3 +118,4 @@ class ChaosAgent:
             for emotion in self.emotions.stack
             if emotion.is_active()
         ]
+

--- a/chaos_stdlib.py
+++ b/chaos_stdlib.py
@@ -48,3 +48,44 @@ def weighted_pick(pairs: List[Tuple[Any, int]], default: Any = None) -> Any:
         if choice <= acc:
             return item
     return default
+
+
+def soft_intensity(
+    raw: Any,
+    default: int = 5,
+    *,
+    lo: int = 0,
+    hi: int = 10,
+    clamp_result: bool = True,
+) -> int:
+    if raw is None:
+        return clamp(default, lo, hi) if clamp_result else default
+    value: Any = raw
+    if isinstance(raw, bool):
+        value = int(raw)
+    elif isinstance(raw, (int, float)):
+        value = raw
+    elif isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return clamp(default, lo, hi) if clamp_result else default
+        try:
+            value = float(stripped)
+        except ValueError:
+            match = re.search(r"-?\d+(?:\.\d+)?", stripped)
+            if match:
+                try:
+                    value = float(match.group(0))
+                except ValueError:
+                    return clamp(default, lo, hi) if clamp_result else default
+            else:
+                return clamp(default, lo, hi) if clamp_result else default
+    else:
+        return clamp(default, lo, hi) if clamp_result else default
+    try:
+        numeric = int(round(float(value)))
+    except (TypeError, ValueError):
+        return clamp(default, lo, hi) if clamp_result else default
+    if clamp_result:
+        return clamp(numeric, lo, hi)
+    return numeric

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -24,3 +24,15 @@ def test_agent_respects_zero_intensity_emotions():
     agent.perceive_sn(sn)
     assert agent.emotions.stack[-1].name == "CALM"
     assert agent.emotions.stack[-1].intensity == 0
+
+
+def test_agent_accepts_fuzzy_intensity_strings():
+    sn = """
+    [EVENT]: listening
+    [EMOTION:HOPE:approx 7 among friends]
+    { tuning to the horizon }
+    """
+    agent = ChaosAgent("Test")
+    agent.perceive_sn(sn)
+    assert agent.emotions.stack[-1].name == "HOPE"
+    assert agent.emotions.stack[-1].intensity == 7

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -12,3 +12,15 @@ def test_agent_step_minimal():
     assert isinstance(rep.symbols, dict)
     assert rep.action is None or isinstance(rep.action, Action)
     assert isinstance(rep.dreams, list)
+
+
+def test_agent_respects_zero_intensity_emotions():
+    sn = """
+    [EVENT]: grounding
+    [EMOTION:CALM:0]
+    { breathing together }
+    """
+    agent = ChaosAgent("Test")
+    agent.perceive_sn(sn)
+    assert agent.emotions.stack[-1].name == "CALM"
+    assert agent.emotions.stack[-1].intensity == 0


### PR DESCRIPTION
## Summary
- preserve explicit emotion intensities, including zero, when the CHAOS agent ingests scripts
- default invalid intensity payloads to a neutral baseline instead of overwriting valid values
- cover the regression with a unit test that verifies zero-intensity emotions are retained

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc2157d99083279b4f8033c4663d59