### PR TITLE
Fix README links to use emre2821 repository path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CHAOS: Symbolic–Operational Language for EdenOS
 
-[![Tests](https://github.com/Paradigm-Eden/05_CHAOS_Coding_Language/actions/workflows/tests.yml/badge.svg)](https://github.com/Paradigm-Eden/05_CHAOS_Coding_Language/actions/workflows/tests.yml)
-[![Pylint](https://github.com/Paradigm-Eden/05_CHAOS_Coding_Language/actions/workflows/pylint.yml/badge.svg)](https://github.com/Paradigm-Eden/05_CHAOS_Coding_Language/actions/workflows/pylint.yml)
-[![codecov](https://codecov.io/gh/Paradigm-Eden/05_CHAOS_Coding_Language/graph/badge.svg)](https://codecov.io/gh/Paradigm-Eden/05_CHAOS_Coding_Language)
+[![Tests](https://github.com/emre2821/05_CHAOS_Coding_Language/actions/workflows/tests.yml/badge.svg)](https://github.com/emre2821/05_CHAOS_Coding_Language/actions/workflows/tests.yml)
+[![Pylint](https://github.com/emre2821/05_CHAOS_Coding_Language/actions/workflows/pylint.yml/badge.svg)](https://github.com/emre2821/05_CHAOS_Coding_Language/actions/workflows/pylint.yml)
+[![codecov](https://codecov.io/gh/emre2821/05_CHAOS_Coding_Language/graph/badge.svg)](https://codecov.io/gh/emre2821/05_CHAOS_Coding_Language)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: Eden Cooperative](https://img.shields.io/badge/license-Eden%20Cooperative-purple.svg)](LICENSE)
 
@@ -407,7 +407,7 @@ For comprehensive project information, see:
 
 ```bash
 # Clone the repository (skip this if you're already in a local clone)
-git clone https://github.com/Paradigm-Eden/05_CHAOS_Coding_Language.git
+git clone https://github.com/emre2821/05_CHAOS_Coding_Language.git
 cd 05_CHAOS_Coding_Language
 
 # Create virtual environment


### PR DESCRIPTION
### Motivation
- Remove incorrect `Paradigm-Eden/05_CHAOS_Coding_Language` references in `README.md` so badges and the clone instruction point to the correct `emre2821` repository.

### Description
- Updated the three GitHub badge URLs and the development `git clone` command in `README.md` from `Paradigm-Eden/05_CHAOS_Coding_Language` to `emre2821/05_CHAOS_Coding_Language`.

### Testing
- Verified there are no remaining `Paradigm-Eden/05_CHAOS` occurrences by running `rg -n -F` against `README.md` and inspected the change with `git diff`, with the search returning no matches and the commit completing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca61b608d083278b8f24e3408a8149)

## Summary by Sourcery

Update README repository references to point to the correct GitHub project under the emre2821 account.

Documentation:
- Correct README status badge URLs to reference the emre2821/05_CHAOS_Coding_Language repository.
- Update README clone command to use the emre2821 GitHub repository path.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR corrects repository references in the README file by updating all GitHub URLs from the old `Paradigm-Eden/05_CHAOS_Coding_Language` path to the new `emre2821/05_CHAOS_Coding_Language` path. The changes ensure that badge links (Tests, Pylint, codecov) and the git clone command point to the correct repository location.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->